### PR TITLE
Волна у курсора живёт настоящей громкостью

### DIFF
--- a/main.swift
+++ b/main.swift
@@ -60,32 +60,31 @@ func currentHotkey() -> Hotkey {
 
 // MARK: - Иконки (рисуем векторно, template → ЧБ под тему строки меню)
 
-func barsImage(_ heights: [CGFloat], red: Bool) -> NSImage {
+/// Столбики в строке меню. Цвет не задан — шаблонная иконка покоя,
+/// чёрно-белая под тему строки меню. Задан — состояние: красный «пишу»,
+/// синий «думаю», те же цвета, что у плашки возле курсора.
+func barsImage(_ heights: [CGFloat], color: NSColor? = nil) -> NSImage {
     let img = NSImage(size: NSSize(width: 22, height: 18), flipped: false) { _ in
-        let color = red ? NSColor(red: 0.9, green: 0.2, blue: 0.2, alpha: 1) : NSColor.black
-        color.setFill()
+        (color ?? NSColor.black).setFill()
         for (i, h) in heights.enumerated() {
             let r = NSRect(x: 1 + CGFloat(i) * 4.2, y: 9 - h / 2, width: 2.8, height: h)
             NSBezierPath(roundedRect: r, xRadius: 1.3, yRadius: 1.3).fill()
         }
         return true
     }
-    img.isTemplate = !red
+    img.isTemplate = (color == nil)
     return img
 }
 
-func dotsImage(_ count: Int) -> NSImage {
-    let img = NSImage(size: NSSize(width: 22, height: 18), flipped: false) { _ in
-        NSColor.black.setFill()
-        for i in 0..<count {
-            let r = NSRect(x: 1.2 + CGFloat(i) * 6.5, y: 7.2, width: 3.6, height: 3.6)
-            NSBezierPath(ovalIn: r).fill()
-        }
-        return true
-    }
-    img.isTemplate = true
-    return img
-}
+/// Красный — идёт запись, синий — Писарь думает. Те же два цвета
+/// у столбиков в плашке возле курсора: строка меню и плашка всегда
+/// говорят об одном и том же.
+let recColor = NSColor(red: 0.9, green: 0.2, blue: 0.2, alpha: 1)
+let busyColor = NSColor.systemBlue
+
+/// Доля высоты у столбиков, пока идёт распознавание, — ровный ряд.
+/// Такой же ряд в это время стоит и в плашке.
+let BUSY_BAR: CGFloat = 0.35
 
 // MARK: - Приложение
 
@@ -180,32 +179,44 @@ final class App: NSObject, NSApplicationDelegate {
         animTimer = nil
         switch s {
         case .idle:
-            statusItem.button?.image = barsImage([5, 9, 13, 9, 5], red: false)
+            statusItem.button?.image = barsImage([5, 9, 13, 9, 5])
             wave.hide()
         case .rec:
-            // Анимация виртуальная: нажал — сразу пошла. Стиль — эквалайзер:
-            // столбики прыгают независимо. От настоящей громкости отказались:
-            // у измерителя Apple инерция, и честная волна выглядела вялой.
-            statusItem.button?.image = barsImage([6, 11, 14, 11, 6], red: true)
+            // Столбики показывают настоящую громкость с микрофона: молчишь —
+            // лежат, говоришь — пляшут. Волну у курсора и иконку в строке меню
+            // кормит один таймер одними и теми же числами, поэтому они всегда
+            // об одном и том же звуке.
+            statusItem.button?.image = barsImage([3, 3, 3, 3, 3], color: recColor)
             var tick = 0
-            animTimer = Timer.scheduledTimer(withTimeInterval: 0.09, repeats: true) { [weak self] _ in
+            // 60 кадров в секунду: микрофон приносит громкость раз в ~85 мс,
+            // промежуточные кадры доводят столбики до неё плавно. На 20
+            // кадрах движение читалось рывками — «низкий fps».
+            let t = Timer(timeInterval: 1.0 / 60, repeats: true) { [weak self] _ in
                 guard let self else { return }
-                let h = (0..<5).map { _ in CGFloat.random(in: 3...14) }
-                self.statusItem.button?.image = barsImage(h, red: true)
-                self.wave.tick()
+                self.wave.tick(level: CGFloat(self.mic.level))
+                tick += 1
+                // Иконке в строке меню хватает и 20 кадров: она размером
+                // с ноготь, а каждый кадр там — новая картинка.
+                // столбики 0…1 → высоты иконки: 3 пункта в тишине, 14 на голосе
+                if tick % 3 == 0 {
+                    self.statusItem.button?.image = barsImage(self.wave.bars.map { 3 + 11 * $0 },
+                                                              color: recColor)
+                }
                 // окно с кареткой могли передвинуть прямо во время диктовки —
                 // раз в полсекунды спрашиваем место заново и едем за ним
-                tick += 1
-                if tick % 6 == 0, self.waveEnabled { self.wave.follow(typingAnchorIfKnown()) }
+                if tick % 30 == 0, self.waveEnabled { self.wave.follow(typingAnchorIfKnown()) }
             }
+            // В общих режимах: иначе открытое меню или перетаскивание
+            // плашки останавливает волну до конца жеста.
+            RunLoop.main.add(t, forMode: .common)
+            animTimer = t
         case .busy:
-            wave.busy() // серые столбики: «услышал, распознаю»
-            var tick = 0
-            statusItem.button?.image = dotsImage(1)
-            animTimer = Timer.scheduledTimer(withTimeInterval: 0.3, repeats: true) { [weak self] _ in
-                tick += 1
-                self?.statusItem.button?.image = dotsImage(tick % 3 + 1)
-            }
+            wave.busy() // плашка на месте, столбики синие: «услышал, распознаю»
+            // Иконка говорит ровно то же и тем же цветом: раньше тут бежали
+            // точки, и строка меню с плашкой рассказывали разными словами
+            // об одном состоянии.
+            statusItem.button?.image = barsImage(
+                [CGFloat](repeating: 3 + 11 * BUSY_BAR, count: 5), color: busyColor)
         }
     }
 
@@ -828,7 +839,7 @@ final class App: NSObject, NSApplicationDelegate {
 
     func flashError() {
         // короткая красная вспышка иконки вместо алерта
-        statusItem.button?.image = barsImage([13, 4, 13, 4, 13], red: true)
+        statusItem.button?.image = barsImage([13, 4, 13, 4, 13], color: recColor)
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { [weak self] in
             self?.setState(.idle)
         }

--- a/swift/Mic.swift
+++ b/swift/Mic.swift
@@ -23,6 +23,39 @@ final class Mic {
     private let lock = NSLock()
     private(set) var isRecording = false
 
+    /// Громкость для волны, 0…1. Считается в звуковом потоке, читается
+    /// из главного — живёт под тем же локом, что и куски записи.
+    ///
+    /// Это ПИКОВЫЙ измеритель с удержанием: между двумя взглядами волны
+    /// микрофон может прислать и три куска, и ни одного, и всплеск голоса
+    /// не должен пропасть ни в том, ни в другом случае. Поэтому куски
+    /// копят максимум, а взгляд его забирает и обнуляет копилку.
+    private var levelPeak: Float = 0
+    private var levelSeen = false
+    private var levelHeld: Float = 0
+
+    var level: Float {
+        lock.lock(); defer { lock.unlock() }
+        guard levelSeen else { return levelHeld } // куска ещё не было — держим прошлое
+        levelSeen = false
+        levelHeld = levelPeak
+        levelPeak = 0
+        return levelHeld
+    }
+
+    /// Тишина и полный голос в дБ относительно максимума. Ниже пола
+    /// столбики лежат, выше потолка стоят во весь рост. Меряем пики
+    /// по 10 мс, а не среднее по всему куску, поэтому и края взяты
+    /// по-пиковому: тихая комната живёт около −55 дБ, обычная речь
+    /// даёт пики от −35 до −12.
+    private static let dbFloor: Float = -50
+    private static let dbCeil: Float = -15
+
+    /// Кривая громкости. Ухо слышет тихое лучше, чем показывает линейка:
+    /// без поджатия обычная речь болталась бы в нижней трети столбика,
+    /// и волна казалась вялой. 0.6 поднимает середину, не трогая края.
+    private static let curve: Float = 0.6
+
     init() {
         // Сменился микрофон или его формат (воткнули наушники, виртуалка
         // передёрнула устройство) — старый движок больше не годится,
@@ -64,7 +97,28 @@ final class Mic {
                 let k = Float(каналов)
                 for i in 0..<n { mono[i] /= k }
             }
-            self.lock.lock(); self.chunks.append(mono); self.lock.unlock()
+            // Громкость: не среднее по всему куску, а самое громкое
+            // окно в 10 мс внутри него. Кусок в 4096 отсчётов — это ~85 мс;
+            // среднее по такому сроку размазывает слоги в ровный гул,
+            // и волна получается вялой, хотя голос живой.
+            let окно = max(1, Int(self.nativeRate / 100))
+            var peak: Float = 0
+            var i = 0
+            while i < n {
+                let край = min(i + окно, n)
+                var sum: Float = 0
+                for j in i..<край { sum += mono[j] * mono[j] }
+                peak = max(peak, sqrt(sum / Float(край - i)))
+                i = край
+            }
+            let db = 20 * log10(max(peak, 1e-7))
+            let ровно = min(max((db - Self.dbFloor) / (Self.dbCeil - Self.dbFloor), 0), 1)
+            let level = pow(ровно, Self.curve)
+            self.lock.lock()
+            self.chunks.append(mono)
+            self.levelPeak = max(self.levelPeak, level)
+            self.levelSeen = true
+            self.lock.unlock()
         }
 
         e.prepare()
@@ -88,6 +142,7 @@ final class Mic {
         lock.lock()
         let native = chunks.flatMap { $0 }
         chunks = []
+        levelPeak = 0; levelHeld = 0; levelSeen = false // микрофон закрыт — волне показывать нечего
         lock.unlock()
         return Self.resample(native, from: nativeRate, to: 16000)
     }

--- a/swift/WavePanel.swift
+++ b/swift/WavePanel.swift
@@ -3,9 +3,10 @@
 // Волна в строке меню наверху видна плохо, когда экран большой и смотришь
 // на курсор. Эта плашка появляется у текстовой каретки (спрашиваем через
 // Accessibility, разрешение и так есть), а если каретку не отдали —
-// у указателя мыши. Анимация виртуальная, в стиле эквалайзера: она говорит
-// «идёт запись», а не показывает громкость — честная громкость выглядела
-// вялой из-за инерции измерителя Apple.
+// у указателя мыши. Столбики показывают настоящую громкость с микрофона
+// (среднеквадратичную, в децибелах): молчишь — лежат, говоришь — пляшут.
+// Инерцию, из-за которой честная волна раньше выглядела вялой, снимает
+// разная скорость вверх и вниз — см. tick(level:).
 
 import AppKit
 
@@ -180,7 +181,58 @@ func focusedFieldFrame() -> NSRect? {
 
 final class WaveView: NSView {
     var busy = false
-    private var heights: [CGFloat] = [0.4, 0.6, 0.8, 0.6, 0.4]
+
+    /// Сколько столбиков в плашке.
+    static let bars = 13
+
+    /// Высоты столбиков, 0…1. Наружу отданы затем, что этими же числами
+    /// кормится иконка в строке меню: две волны об одном и том же звуке
+    /// и обязаны идти в такт.
+    private(set) var heights = [CGFloat](repeating: 0, count: WaveView.bars)
+
+    /// Сглаженная громкость 0…1 — показываем её, а не сырую: сырая
+    /// дёргается покадрово и читается как рябь.
+    private var level: CGFloat = 0
+
+    /// Своя доля громкости у каждого столбика и своё опоздание в кадрах.
+    /// Перебрасываются РАЗ НА ВСПЛЕСК, а не каждый кадр: покадровый
+    /// рандом читается как дрожь, а разовый — как живой голос, от
+    /// которого столбики дёрнулись вразнобой и снова замерли.
+    private var gain = [CGFloat](repeating: 1, count: WaveView.bars)
+    private var lag = [Int](repeating: 0, count: WaveView.bars)
+
+    /// Кадров с начала всплеска; nil — столбики просто стоят на громкости.
+    private var burst: Int?
+
+    /// Насколько громче должно стать, чтобы это считалось всплеском,
+    /// и на сколько кадров столбики могут разъехаться внутри него
+    /// (9 кадров — это 150 мс).
+    private static let burstTrigger: CGFloat = 0.1
+    private static let burstSpread = 9
+
+    // Кадр — 1/60 секунды, и все доли ниже посчитаны под него. Если
+    // менять частоту таймера в main.swift — пересчитывать и их:
+    // доля за кадр = 1 − (1 − прежняя доля)^(прежняя частота / новая).
+    private static let riseRate: CGFloat = 0.75      // подъём, ~30 мс до цели
+    private static let fallRate: CGFloat = 0.13      // спад на тихой речи, ~120 мс
+    private static let fallLoud: CGFloat = 0.45      // добавка к спаду на полной громкости
+
+    /// Кадров с прошлой пересыпки — по нему громкий голос гонит
+    /// столбики дальше, не дожидаясь нового всплеска.
+    private var sinceRoll = 0
+
+    /// Масштаб появления, 1 — плашка в полный рост. Рисуем от левого
+    /// верхнего угла: там каретка, и плашка будто выпрыгивает из-под неё.
+    var scale: CGFloat = 1
+
+    /// С какой громкости плашка начинает частить.
+    private static let livelyFrom: CGFloat = 0.35
+
+    /// Горка: середина выше краёв, чтобы плашка читалась волной,
+    /// а не забором. Считаем от места столбика в ряду.
+    private static func shape(_ i: Int) -> CGFloat {
+        0.72 + 0.28 * sin(CGFloat.pi * (CGFloat(i) + 0.5) / CGFloat(bars))
+    }
 
     // Перетаскивание ведём сами, без isMovableByWindowBackground:
     // так «пользователь перетащил» — это буквально нажатие мышью
@@ -212,17 +264,75 @@ final class WaveView: NSView {
         dragMouse = nil; dragOrigin = nil; dragged = false
     }
 
-    /// Один в один как иконка в трее: каждый столбик каждый кадр прыгает
-    /// на случайную высоту, без сглаживания. Оба кормит один таймер,
-    /// так что пляшут они синхронно по темпу.
-    func tick() {
-        for i in 0..<heights.count {
-            heights[i] = CGFloat.random(in: 0.2...1.0)
+    /// Кадр волны по свежей громкости с микрофона. Вверх — почти рывком
+    /// (голос должен попадать в столбик в тот же кадр, иначе волна
+    /// плетётся за речью), вниз — медленнее, иначе столбики рушатся
+    /// в паузах между слогами и волна начинает мигать.
+    /// Новая раскладка столбиков. Чем громче голос, тем шире разброс
+    /// высот и тем теснее столбики по времени: на крике они должны
+    /// разлетаться, на тихой речи — вести себя смирно.
+    private func roll() {
+        let низ = 0.75 - 0.55 * level
+        let разброс = max(3, Self.burstSpread - Int(6 * level))
+        for i in 0..<Self.bars {
+            gain[i] = CGFloat.random(in: низ...1.0)
+            lag[i] = Int.random(in: 0...разброс)
         }
+        burst = 0
+        sinceRoll = 0
+    }
+
+    func tick(level target: CGFloat) {
+        let рост = target - level
+        level += рост * (рост > 0 ? Self.riseRate : Self.fallRate)
+        sinceRoll += 1
+
+        // Голос прибавил — всплеск: каждый столбик берёт себе новую долю
+        // громкости и новое опоздание. Пока прошлый всплеск не отыграл,
+        // новый не начинаем, иначе доли перебрасывались бы каждый кадр
+        // и вернулась бы дрожь.
+        if рост > Self.burstTrigger, burst == nil {
+            roll()
+        } else if level > Self.livelyFrom, sinceRoll >= max(4, Int(18 - 15 * level)) {
+            // А пока голос громкий, столбики пересыпаются и сами, без
+            // нового всплеска: на полной громкости раз в 100 мс, у порога
+            // — втрое реже. Честной громкости в этом уже нет, это
+            // украшение: на крике плашка должна выглядеть так же бойко,
+            // как звучит голос, а громкость к тому времени упёрлась
+            // в потолок и сама по себе перестала что-либо показывать.
+            roll()
+        }
+
+        for i in 0..<heights.count {
+            // столбик, чья очередь ещё не подошла, стоит как стоял —
+            // от этого всплеск и выглядит разнобоем, а не общим прыжком
+            if let age = burst, age < lag[i] { continue }
+            let свой = level * Self.shape(i) * gain[i]
+            // Вверх столбик идёт всегда рывком, вниз — тем резче, чем
+            // громче голос: на тихой речи оседает плавно, на громкой
+            // рушится почти мгновенно. Отсюда и размах: на крике столбики
+            // не покачиваются около одной высоты, а рушатся и взлетают.
+            let скорость = свой > heights[i] ? Self.riseRate
+                                             : Self.fallRate + Self.fallLoud * level
+            heights[i] += (свой - heights[i]) * скорость
+        }
+
+        if let age = burst { burst = age < Self.burstSpread ? age + 1 : nil }
         needsDisplay = true
     }
 
     override func draw(_ dirtyRect: NSRect) {
+        let растёт = scale != 1
+        if растёт {
+            NSGraphicsContext.saveGraphicsState()
+            let t = NSAffineTransform()
+            t.translateX(by: 0, yBy: bounds.height) // якорь — левый верхний угол
+            t.scaleX(by: scale, yBy: scale)
+            t.translateX(by: 0, yBy: -bounds.height)
+            t.concat()
+        }
+        defer { if растёт { NSGraphicsContext.restoreGraphicsState() } }
+
         // светлая плашка: белая, с тонкой окантовкой, чтобы читалась
         // и на белом фоне, и на тёмном
         let pill = NSBezierPath(roundedRect: bounds.insetBy(dx: 0.5, dy: 0.5),
@@ -234,21 +344,33 @@ final class WaveView: NSView {
         pill.stroke()
 
         let bars = heights.count
-        let barW: CGFloat = 4
-        let gap: CGFloat = 4
+        // 13 столбиков: 2,5 пункта ширины с зазором 1,5, поля по краям
+        // почти по девять. Шире ряд делать некуда — крайний столбик
+        // полез бы за скруглённый торец плашки.
+        let barW: CGFloat = 2.5
+        let gap: CGFloat = 1.5
         let totalW = CGFloat(bars) * barW + CGFloat(bars - 1) * gap
         let x0 = (bounds.width - totalW) / 2
-        let maxH = bounds.height - 8
+        // Полей сверху и снизу — по пункту: столбик на всплеске должен
+        // выстреливать во всю плашку, иначе размах пропадает даром.
+        let maxH = bounds.height - 2
 
         // цвет столбиков выбирается в меню приложения
         let chosen = UserDefaults.standard.string(forKey: "waveColor") ?? "dark"
         let barColor: NSColor = chosen == "green" ? .systemGreen
             : chosen == "red" ? .systemRed
             : .black.withAlphaComponent(0.78)
-        (busy ? NSColor.black.withAlphaComponent(0.25) : barColor).setFill()
+        // Пока Писарь думает, плашка остаётся на месте и синеет: работа
+        // не кончилась, текст сейчас появится — а серые столбики
+        // выглядели так, будто волна умерла.
+        (busy ? busyColor : barColor).setFill()
+        // В покое столбик должен быть кружком, а не лежачим овалом:
+        // нижний предел высоты равен ширине. Вертикальный овал —
+        // это barW * 1.75.
+        let restH = barW
         for i in 0..<bars {
-            let sway = busy ? 0.35 : heights[i]
-            let h = max(3, maxH * sway)
+            let sway = busy ? BUSY_BAR : heights[i]
+            let h = max(restH, maxH * sway)
             let r = NSRect(x: x0 + CGFloat(i) * (barW + gap),
                            y: (bounds.height - h) / 2, width: barW, height: h)
             NSBezierPath(roundedRect: r, xRadius: barW / 2, yRadius: barW / 2).fill()
@@ -328,6 +450,7 @@ final class Toast {
 final class WavePanel {
     private let panel: NSPanel
     private let view = WaveView()
+    private var popTimer: Timer?
 
     /// Куда пользователь перетащил плашку. Пока не таскал — nil,
     /// и плашка ходит за текстовой кареткой.
@@ -347,7 +470,7 @@ final class WavePanel {
     }
 
     init() {
-        panel = NSPanel(contentRect: NSRect(x: 0, y: 0, width: 78, height: 26),
+        panel = NSPanel(contentRect: NSRect(x: 0, y: 0, width: 68, height: 26),
                         styleMask: [.borderless, .nonactivatingPanel],
                         backing: .buffered, defer: true)
         panel.level = .statusBar
@@ -381,7 +504,43 @@ final class WavePanel {
         NSLog("Гига волна: показ в \(origin)\(Self.pinned != nil ? " (прибита)" : "")")
         panel.setFrameOrigin(origin)
         panel.orderFrontRegardless()
+        pop()
     }
+
+    /// Появление: плашка за 12 кадров вырастает из левого верхнего угла,
+    /// в конце чуть перелетает свой размер и садится обратно. Само окно
+    /// всё это время стоит на месте в полный рост — растёт только рисунок,
+    /// поэтому ни положение, ни перетаскивание от анимации не зависят.
+    private func pop() {
+        popTimer?.invalidate()
+        let кадров = 12
+        var кадр = 0
+        view.scale = Self.popFrom
+        view.needsDisplay = true
+        let t = Timer(timeInterval: 1.0 / 60, repeats: true) { [weak self] tm in
+            guard let self else { tm.invalidate(); return }
+            кадр += 1
+            if кадр >= кадров {
+                self.view.scale = 1
+                tm.invalidate()
+                self.popTimer = nil
+            } else {
+                // easeOutBack: к концу перелетает размер примерно на 7%
+                let x = CGFloat(кадр) / CGFloat(кадров) - 1
+                let ход = 1 + (Self.popBack + 1) * x * x * x + Self.popBack * x * x
+                self.view.scale = Self.popFrom + (1 - Self.popFrom) * ход
+            }
+            self.view.needsDisplay = true
+            self.panel.invalidateShadow() // тень должна ужиматься вместе с плашкой
+        }
+        RunLoop.main.add(t, forMode: .common)
+        popTimer = t
+    }
+
+    /// С какого размера начинается появление и насколько сильно
+    /// плашка перелетает свой размер в конце.
+    private static let popFrom: CGFloat = 0.35
+    private static let popBack: CGFloat = 1.2
 
     /// Во время записи: окно с кареткой переехало — плашка следом.
     /// Прибитую не трогаем; когда её тащат мышью — тем более.
@@ -393,12 +552,24 @@ final class WavePanel {
         panel.setFrameOrigin(o)
     }
 
-    func tick() { view.tick() }
+    func tick(level: CGFloat) { view.tick(level: level) }
+
+    /// Столбики для иконки в строке меню: там места на пять, поэтому
+    /// берём каждый третий — иконка живёт тем же звуком, что и плашка.
+    var bars: [CGFloat] {
+        let h = view.heights
+        return (0..<5).map { h[$0 * (h.count - 1) / 4] }
+    }
 
     func busy() {
         view.busy = true
         view.needsDisplay = true
     }
 
-    func hide() { panel.orderOut(nil) }
+    func hide() {
+        popTimer?.invalidate()
+        popTimer = nil
+        view.scale = 1
+        panel.orderOut(nil)
+    }
 }


### PR DESCRIPTION
Столбики прыгали на случайную высоту: волна говорила «идёт запись», но не показывала голос. Теперь микрофон меряет громкость в децибелах — пик по окну в 10 мс, с удержанием между кадрами, чтобы всплеск не пропал, — и волна идёт за ней. Столбиков стало тринадцать, на всплеск каждый берёт свою долю и своё опоздание, а на громком разброс и скорость падения растут: получается размах, а не покачивание. Кадров теперь 60 в секунду, появляется плашка прыжком из левого верхнего угла.

Иконка в строке меню питается теми же числами и теми же цветами: красный — пишу, синий — думаю. Бегущие точки на распознавании убраны, они рассказывали о том же состоянии другими словами, чем плашка.

Демонстрация работы индикатора.


https://github.com/user-attachments/assets/4a9eeb16-d45b-4211-a14a-57c6baf3c4b1

