### PR TITLE
Фокус в поле

### DIFF
--- a/main.swift
+++ b/main.swift
@@ -1211,7 +1211,10 @@ final class App: NSObject, NSApplicationDelegate {
         // а не про координаты каретки: терминалы и Electron часто скрывают,
         // ГДЕ каретка, но поле-то у них есть и ⌘V сработает. Если поля нет —
         // ⌘V всё равно нажмём, но буфер НЕ затираем и подсказываем.
-        let inField = hasTextFocus()
+        // Молчание Accessibility — не отказ: в Electron дерево может быть
+        // ещё не построено, а ⌘V там прекрасно работает. Ругаемся, только
+        // когда точно знаем, что фокус не в тексте.
+        let inField = textFocus() != .notField
         // Нажать ⌘V за пользователя можно только с разрешением Accessibility.
         let trusted = AXIsProcessTrusted() || CGPreflightPostEventAccess()
         guard trusted else {
@@ -1226,28 +1229,15 @@ final class App: NSObject, NSApplicationDelegate {
             keepClipboard() // вставить нечем — диктовка остаётся в буфере
             return
         }
-        // Снимок поля до вставки: по нему потом решим, состоялась ли она.
-        let caretBefore = caretIndex()
-        let lengthBefore = focusedTextLength()
         pressKey(9, .maskCommand) // ⌘V
         if inField {
+            // Буфер возвращаем человеку. Проверять, дошла ли вставка на самом
+            // деле, мы пробовали — по каретке и числу символов в поле, — и от
+            // этого пришлось отказаться: Electron (VS Code и плагины в нём)
+            // отвечает Accessibility как попало, и проверка объявляла неудачу
+            // поверх удавшейся вставки.
             DispatchQueue.main.asyncAfter(deadline: .now() + Self.clipboardHold) { [weak self] in
-                guard let self else { return }
-                // Текст действительно встал в поле? Каретка должна была уехать
-                // вперёд или в поле прибавиться символов. Если убедиться не
-                // удалось — буфер не возвращаем: пусть лучше пропадёт чужая
-                // копия, чем наговорённое, которое больше взять неоткуда.
-                let вперёд = { (b: Int?, a: Int?) in
-                    if let b, let a { return a > b } else { return false }
-                }
-                if вперёд(caretBefore, caretIndex()) || вперёд(lengthBefore, focusedTextLength()) {
-                    self.restoreClipboard()
-                } else {
-                    NSLog("Гига вставка: подтверждения нет — диктовку оставляю в буфере")
-                    self.keepClipboard()
-                    Toast.shared.show(L("Вставка не прошла — диктовка в буфере, нажми ⌘V",
-                                        "The paste didn't land — your dictation is on the clipboard, press ⌘V"))
-                }
+                self?.restoreClipboard()
             }
             // Менюшка: сырой текст вставлен, предложить причесать.
             if offerChips, Brain.shared.ready, Brain.shared.chipsEnabled {

--- a/swift/WavePanel.swift
+++ b/swift/WavePanel.swift
@@ -103,8 +103,6 @@ private func axBounds(_ el: AXUIElement, _ range: CFRange) -> NSRect? {
     return out
 }
 
-/// Есть ли сейчас фокус в текстовом поле (даже если оно скрывает,
-/// ГДЕ каретка): по этому решаем, вставится ли ⌘V.
 /// Текст, выделенный в фокусном поле. nil — выделения нет (или приложение
 /// его не отдаёт: Chrome и Electron через раз, терминалы никогда).
 /// Сначала спрашиваем сам текст (AXSelectedText); если его нет, но диапазон
@@ -121,30 +119,55 @@ func selectedTextViaAX() -> (text: String?, length: Int) {
     return (nil, Int(sel.length))
 }
 
-func hasTextFocus() -> Bool {
-    guard let el = axFocusedElement() else { return false }
-    return axSelectedRange(el) != nil
-}
+/// Что известно про фокус: поле есть, поля нет — или приложение молчит.
+/// Молчание не значит «нет»: Chromium и всё, что на нём (Electron, Cursor,
+/// VS Code), строит дерево доступности лениво и до первого запроса не отдаёт
+/// даже фокусный элемент. Принимать это за «курсор не в тексте» — значит
+/// ругаться на удавшуюся вставку.
+enum TextFocus { case field, notField, unknown }
 
-/// Номер символа, перед которым стоит каретка. По нему видно, подействовала
-/// ли вставка: после ⌘V каретка обязана уехать вперёд. nil — приложение
-/// не отдаёт положение, и судить не по чему.
-func caretIndex() -> Int? {
-    guard let el = axFocusedElement(), let r = axSelectedRange(el) else { return nil }
-    return r.location
-}
+/// Роли, в которые ⌘V попадёт. Одного диапазона выделения мало: Finder,
+/// когда курсор нигде не стоит, отдаёт AXGroup, и диапазон у него тоже есть —
+/// по нему мы принимали рабочий стол за текстовое поле.
+private let textRoles: Set<String> = ["AXTextField", "AXTextArea", "AXComboBox",
+                                      "AXSecureTextField", "AXSearchField"]
 
-/// Сколько символов в фокусном поле. Второй свидетель вставки — на случай,
-/// когда каретку приложение показывает, а двигать её забывает.
-func focusedTextLength() -> Int? {
-    guard let el = axFocusedElement() else { return nil }
+func textFocus() -> TextFocus {
+    guard let el = axFocusedElement() else {
+        // Молчит. Первое молчание от этого приложения — повод разбудить
+        // дерево и поверить на слово: скорее всего это Chromium, который
+        // ещё не проснулся. Молчит и после побудки — значит фокуса
+        // действительно нет.
+        return wakeAccessibility() ? .unknown : .notField
+    }
+    guard axSelectedRange(el) != nil else { return .notField }
     var ref: CFTypeRef?
-    guard AXUIElementCopyAttributeValue(el, "AXNumberOfCharacters" as CFString,
-                                        &ref) == .success,
-          let n = ref as? Int
-    else { return nil }
-    return n
+    let role = (AXUIElementCopyAttributeValue(el, "AXRole" as CFString, &ref) == .success
+                ? ref as? String : nil) ?? ""
+    return textRoles.contains(role) ? .field : .notField
 }
+
+/// Просьба к Chromium построить дерево доступности. Ключа два, оба
+/// исторические: на AXManualAccessibility отзывается Electron,
+/// на AXEnhancedUserInterface — сам Chromium и часть старых приложений.
+/// Дерево появляется не сразу, поэтому первая диктовка в такое окно
+/// всё равно пройдёт вслепую.
+/// Возвращает true, если это приложение мы будим впервые: тогда его
+/// молчанию даётся один заход форы.
+private var wokenApps = Set<String>()
+
+@discardableResult
+private func wakeAccessibility() -> Bool {
+    guard let app = NSWorkspace.shared.frontmostApplication else { return false }
+    let el = AXUIElementCreateApplication(app.processIdentifier)
+    AXUIElementSetAttributeValue(el, "AXManualAccessibility" as CFString, kCFBooleanTrue)
+    AXUIElementSetAttributeValue(el, "AXEnhancedUserInterface" as CFString, kCFBooleanTrue)
+    return wokenApps.insert(app.bundleIdentifier ?? "?").inserted
+}
+
+/// Есть ли сейчас фокус в текстовом поле (даже если оно скрывает,
+/// ГДЕ каретка): по этому решаем, вставится ли ⌘V.
+func hasTextFocus() -> Bool { textFocus() == .field }
 
 /// Точка текстовой каретки (низ) в кокоа-координатах, если приложение
 /// отдаёт её честно. Пустое выделение часто отдаёт мусорные границы —


### PR DESCRIPTION
Две ошибки в определении «есть ли куда вставлять», обе всплыли после
возврата буфера в 3.6.

## Electron: молчание принималось за отказ

Диктовка в поле плагина в Cursor вставлялась нормально, но Писарь ругался
«Курсор был не в тексте», оставлял диктовку в буфере и тем самым затирал
то, что человек скопировал сам.

Причина: Chromium (а значит Electron, Cursor, VS Code) строит дерево
доступности лениво. Пока его никто не попросил, `AXFocusedUIElement`
не отдаёт вообще ничего — ни системе, ни приложению напрямую. Вот запись
диагностики в момент вставки:

app=com.todesktop.230313mzl4w4u92  hasTextFocus=false
    системный:  нет элемента
    прикладной: нет элемента

Теперь у фокуса три состояния вместо двух: поле есть, поля нет, приложение
молчит. Молчание — не отказ: в первый раз просим Chromium построить дерево
(`AXManualAccessibility` — на него отзывается Electron,
`AXEnhancedUserInterface` — сам Chromium) и верим на слово. Молчит и после
побудки — значит фокуса действительно нет.

Побудка работает. Тот же Cursor после неё:

системный:  роль=AXTextField/AXSearchField диапазон=есть

Первая диктовка в свежее окно всё равно проходит вслепую — дерево строится
не мгновенно, — поэтому молчанию даётся ровно один заход форы, по одному
на приложение.

## Finder: рабочий стол числился текстовым полем

Обратная ошибка. Проверка была «отдаёт ли фокусный элемент диапазон
выделения», а Finder, когда курсор нигде не стоит, отдаёт `AXGroup` —
и диапазон у него тоже есть. Поэтому предупреждение не показывалось как раз
там, где оно нужно.

Полем теперь считаются только текстовые роли: `AXTextField`, `AXTextArea`,
`AXComboBox`, `AXSecureTextField`, `AXSearchField`. По той же диагностике
это ровно то, что отдают настоящие поля: Terminal — `AXTextArea` (4534
знака), Telegram — `AXTextArea`, поле Cursor — `AXTextField`.

## Заодно убрана проверка «дошла ли вставка»

В 3.6 после ⌘V сверялись положение каретки и число символов в поле, и при
неудаче показывалось «Вставка не прошла». В Electron это срабатывало поверх
удавшейся вставки: поле отвечает неподвижными цифрами, и отличить их от
настоящей неудачи нечем. Проверку и её сообщение убрал совсем — опираемся
на единственный надёжный признак, который известен до вставки: есть ли
фокус в текстовом поле.